### PR TITLE
Small fixes to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ devToolsProject.run(
         String stdout = data.venv.run(
           label: 'ansible-lint',
           returnStdout: true,
-          script: 'ansible-lint -c .ansible-lint.yml',
+          script: 'ansible-lint --offline -c .ansible-lint.yml',
         )
 
         // If only warnings are found, ansible-lint will exit with code 0 but still write


### PR DESCRIPTION
This PR (hopefully) fixes an issue where ansible-lint would install roles to the node's user cache directory, which could cause problems when running CI for those roles later. Also, it adds the  directory to the list of things that  should ignore as a preemptive measure.