### PR TITLE
Add yamllint check to Jenkinsfile

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+ignore: |
+  .ansible
+  .venv
+
+extends: default
+
+rules:
+  line-length:
+    max: 90

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ devToolsProject.run(
         }
       },
       groovylint: { groovylint.checkSingleFile(path: './Jenkinsfile') },
+      yamllint: { data.venv.run('yamllint --strict .') },
     )
   },
   deployWhen: { devToolsProject.shouldDeploy(defaultBranch: 'main') },


### PR DESCRIPTION
Although ansible-lint uses yamllint as a dependency, it is nice to have a separate yamllint check in the Jenkinsfile.